### PR TITLE
nixos 24.05 -> 24.11

### DIFF
--- a/config/neovim/lsp.lua
+++ b/config/neovim/lsp.lua
@@ -92,7 +92,7 @@ nvim_lsp['julials'].setup {
   }
 }
 
-nvim_lsp['tsserver'].setup {
+nvim_lsp['ts_ls'].setup {
   on_attach = on_attach,
   capabilities = capabilities,
 }

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733482664,
-        "narHash": "sha256-ZD+h1fwvZs+Xvg46lzTWveAqyDe18h9m7wZnTIJfFZ4=",
+        "lastModified": 1734366194,
+        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e38d3dd1d355a003cc63e8fe6ff66ef2257509ed",
+        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733516684,
-        "narHash": "sha256-yz3mZyTnPlxZW2f51kJyfofDsBeX7WxAPvTXZtr2lW4=",
+        "lastModified": 1733854371,
+        "narHash": "sha256-K9qGHniYBbjqVcEiwXyiofj/IFf78L5F0/FCf+CKyr0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "dd20ebde771edbdececade73dbb8791ff987d0db",
+        "rev": "dee4425dcee3149475ead0cb6a616b8a028c5888",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1735141468,
+        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -107,16 +107,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1733482664,
+        "narHash": "sha256-ZD+h1fwvZs+Xvg46lzTWveAqyDe18h9m7wZnTIJfFZ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "e38d3dd1d355a003cc63e8fe6ff66ef2257509ed",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731682434,
-        "narHash": "sha256-HnZFPB7akVIy0KuPq/tEkiB+Brt1qi0DUIDzR8z25qI=",
+        "lastModified": 1733516684,
+        "narHash": "sha256-yz3mZyTnPlxZW2f51kJyfofDsBeX7WxAPvTXZtr2lW4=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "a6b9cf0b7805e2c50829020a73e7bde683fd36dd",
+        "rev": "dd20ebde771edbdececade73dbb8791ff987d0db",
         "type": "github"
       },
       "original": {
@@ -166,27 +166,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,12 @@
   description = "My system config flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-24.05";
+    home-manager.url = "github:nix-community/home-manager/release-24.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     agenix.url = "github:ryantm/agenix";
     agenix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
         inherit agenix;
       };
       my-overrides = import overlays/default.nix;
+      overlays = [ extra-pkgs-overlay my-overrides ];
     in {
 
     # FIXME: tom user should be created and have zsh shell
@@ -40,7 +41,7 @@
       work = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [ 
-          ({ config, pkgs, ... }: { nixpkgs.overlays = [ my-overrides extra-pkgs-overlay ]; })
+          ({ config, pkgs, ... }: { nixpkgs.overlays = overlays; })
           nixos-wsl.nixosModules.default
           ./work-configuration.nix 
           #agenix.nixosModules.default
@@ -66,7 +67,7 @@
       philadelphia = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [ 
-          ({ config, pkgs, ... }: { nixpkgs.overlays = [ my-overrides extra-pkgs-overlay ]; })
+          ({ config, pkgs, ... }: { nixpkgs.overlays = overlays; })
           ./portege-configuration.nix 
           agenix.nixosModules.default
           home-manager.nixosModules.home-manager {
@@ -91,7 +92,7 @@
       katana = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [ 
-          ({ config, pkgs, ... }: { nixpkgs.overlays = [ my-overrides extra-pkgs-overlay ]; })
+          ({ config, pkgs, ... }: { nixpkgs.overlays = overlays; })
           ./katana-configuration.nix 
           agenix.nixosModules.default
           home-manager.nixosModules.home-manager {

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -23,7 +23,7 @@
 
       ${pkgs.tmux}/bin/tmux kill-session -t Tasks
       ${pkgs.tmux}/bin/tmux start-server
-      ${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon --start -d --components=pkcs11,secrets,ssh
+      ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --start -d --components=pkcs11,secrets,ssh
     '';
   };
   programs = {

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -23,7 +23,7 @@
 
       ${pkgs.tmux}/bin/tmux kill-session -t Tasks
       ${pkgs.tmux}/bin/tmux start-server
-      ${pkgs.gnome3.gnome-keyring}/bin/gnome-keyring-daemon --start -d --components=pkcs11,secrets,ssh
+      ${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon --start -d --components=pkcs11,secrets,ssh
     '';
   };
   programs = {

--- a/katana-configuration.nix
+++ b/katana-configuration.nix
@@ -6,7 +6,7 @@
 
 {
   imports =
-    [ ./nixos/nvidia-fix.nix
+    [ #./nixos/nvidia-fix.nix
       ./nixos/common.nix
       ./nixos/games.nix
       ./nixos/desktop.nix
@@ -63,9 +63,35 @@
 
   # Video drivers setup
   services.xserver.videoDrivers = [ "nvidia" ];
-  hardware.opengl = {
+  hardware.graphics = {
     enable = true;
-    driSupport32Bit = true;
+    enable32Bit = true;
+  };
+  hardware.nvidia = {
+    # Modesetting is required.
+    modesetting.enable = true;
+
+    # Nvidia power management. Experimental, and can cause sleep/suspend to fail.
+    # Enable this if you have graphical corruption issues or application crashes after waking
+    # up from sleep. This fixes it by saving the entire VRAM memory to /tmp/ instead 
+    # of just the bare essentials.
+    powerManagement.enable = false;
+
+    # Fine-grained power management. Turns off GPU when not in use.
+    # Experimental and only works on modern Nvidia GPUs (Turing or newer).
+    powerManagement.finegrained = false;
+
+    # Use the NVidia open source kernel module (not to be confused with the
+    # independent third-party "nouveau" open source driver).
+    # Support is limited to the Turing and later architectures. Full list of 
+    # supported GPUs is at: 
+    # https://github.com/NVIDIA/open-gpu-kernel-modules#compatible-gpus 
+    # Only available from driver 515.43.04+
+    open = true;
+
+    # Enable the Nvidia settings menu,
+	  # accessible via `nvidia-settings`.
+    nvidiaSettings = true;
   };
 
   # The global useDHCP flag is deprecated, therefore explicitly set to false here.

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -45,7 +45,7 @@ in
     rxvt_unicode-with-plugins
     shared-mime-info
     plasma-workspace
-    gnome3.zenity
+    gnome.zenity
     usbutils
     pciutils
 

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -44,7 +44,7 @@ in
     hicolor-icon-theme
     shared-mime-info
     plasma-workspace
-    gnome.zenity
+    zenity
     usbutils
     pciutils
 

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -42,7 +42,6 @@ in
   environment.systemPackages = with pkgs; [
     alsa-utils
     hicolor-icon-theme
-    rxvt_unicode-with-plugins
     shared-mime-info
     plasma-workspace
     gnome.zenity

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -40,7 +40,7 @@ in
   };
 
   environment.systemPackages = with pkgs; [
-    alsaUtils
+    alsa-utils
     hicolor-icon-theme
     rxvt_unicode-with-plugins
     shared-mime-info

--- a/nixos/games.nix
+++ b/nixos/games.nix
@@ -4,8 +4,8 @@
 {
   # see https://nixos.wiki/wiki/Steam
   # needed for steam 32 bit
-  hardware.opengl.driSupport32Bit = true;
-  hardware.opengl.extraPackages32 = with pkgs.pkgsi686Linux; [ libva ];
+  hardware.graphics.enable32Bit = true;
+  hardware.graphics.extraPackages32 = with pkgs.pkgsi686Linux; [ libva ];
   hardware.pulseaudio.support32Bit = true;
 
   programs.gamemode.enable = true;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -11,6 +11,8 @@ rec {
     };
   });
 
+  alot = prev.unstable.alot;
+
   #openrgb = (import ../overlays/openrgb.nix final prev);
 
 }

--- a/pkgs/syncmail/default.nix
+++ b/pkgs/syncmail/default.nix
@@ -3,7 +3,7 @@
 
 pkgs.writeShellApplication {
   name = "syncmail";
-  runtimeInputs = with pkgs; [ gmailieer (callPackage ../notmuch-tag {}) ];
+  runtimeInputs = with pkgs; [ lieer (callPackage ../notmuch-tag {}) ];
   text = builtins.readFile ./syncmail;
 }
 

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -73,7 +73,7 @@
   console.useXkbConfig = true;
 
   # Video drivers setup
-  services.xserver.videoDrivers = [ "intel" ];
+  services.xserver.videoDrivers = [ "modesetting" ];
 
   hardware.graphics = {
     enable = true;

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -75,7 +75,7 @@
   # Video drivers setup
   services.xserver.videoDrivers = [ "intel" ];
 
-  hardware.opengl = {
+  hardware.graphics = {
     enable = true;
     extraPackages = with pkgs; [
       intel-media-driver # LIBVA_DRIVER_NAME=iHD
@@ -83,7 +83,7 @@
       vaapiVdpau
       libvdpau-va-gl
     ];
-    driSupport32Bit = true;
+    enable32Bit = true;
   };
 
   # User level thunderbolt 3 drivers

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -27,7 +27,7 @@
     [ { device = "/dev/disk/by-label/swap"; }
     ];
 
-  powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
+  powerManagement.cpuFreqGovernor = lib.mkForce "powersave";
 
   boot.initrd.availableKernelModules = [ "xhci_pci" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc" ];
   boot.initrd.kernelModules = [ "dm-snapshot" ];

--- a/profiles/pim/email.nix
+++ b/profiles/pim/email.nix
@@ -67,6 +67,6 @@ in
     (callPackage ../../pkgs/notmuch-imap-tag-mover {})
 
     notmuch
-    gmailieer
+    lieer
   ];
 }

--- a/profiles/teaching.nix
+++ b/profiles/teaching.nix
@@ -34,5 +34,5 @@
   ];
 
   # needed for mysql vscode password saving
-  services.gnome.gnome-keyring.enable = true;
+  services.gnome-keyring.enable = true;
 }

--- a/profiles/work.nix
+++ b/profiles/work.nix
@@ -32,6 +32,5 @@
   home.packages = with pkgs; [
     bump2version
   ];
-
   home.file."${config.xdg.configHome}/pip/pip.conf" = { source = ../config/pip.conf; };
 }


### PR DESCRIPTION
- **use internal pip repo**
- **refactor: gnome3 is now gnome**
- **refactor: gmailieer is now lieer**
- **refactor: 'alsaUtils' has been renamed to/replaced by 'alsa-utils'**
- **fix: rxvt no longer used**
- **refactor: gnome.gnome-keyring was moved to top-level.**
- **refactor: hardware.opengl is now hardware.graphics**
- **refactor: gnome.zenity was moved to top-level**
- **nixos: 24.05 -> 24.11**
- **portege: powersave needs force now for some reason**
- **alot: need to use unstable version until fix is in 24.11 branch**
- **flake: simplify overlays**
- **nixos: 24.05 -> 24.11**
- **portege: apparently we should be using modesetting now**
- **lsp: use tsserver is deprecated**
