### PR TITLE
switch to 25.05

### DIFF
--- a/config/broot/default.nix
+++ b/config/broot/default.nix
@@ -88,7 +88,7 @@ in
     ".config/broot/launcher/refused".source = ./broot-refused;
   };
   programs.zsh  = {
-    initExtra = ''
+    initContent = ''
       # ctrl-l to open broot
       # br comes from home-manager broot zsh integration
       bindkey -s '^l' 'br\n'

--- a/config/zsh.nix
+++ b/config/zsh.nix
@@ -91,7 +91,7 @@ in
       restic-remote = "export $(cat /home/tom/keys/backblaze-backup | xargs) && restic -r s3:https://s3.us-east-005.backblazeb2.com/backupmybackup";
 
       # I can never remember the command to fill pdfs
-      fillpdf = "${pkgs.xournal}/bin/xournal";
+      fillpdf = "${pkgs.xournalpp}/bin/xournalpp";
 
       # or how to create a new devshell
       initds = "nix flake new -t 'github:numtide/devshell'";

--- a/config/zsh.nix
+++ b/config/zsh.nix
@@ -103,7 +103,7 @@ in
       ignoreDups = true;
       expireDuplicatesFirst = true;
     };
-    initExtra = ''
+    initContent = ''
       # setup up autopushd
       setopt autopushd pushdignoredups
 

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747575206,
-        "narHash": "sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY+D81k=",
+        "lastModified": 1750173260,
+        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "4835b1dc898959d8547a871ef484930675cb47f1",
+        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
         "type": "github"
       },
       "original": {
@@ -89,16 +89,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1751810233,
+        "narHash": "sha256-kllkNbIqQi3VplgTMeGzuh1t8Gk8TauvkTRt93Km+tQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "9b0873b46c9f9e4b7aa01eb634952c206af53068",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -147,27 +147,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749668643,
-        "narHash": "sha256-gaWJEWGBW/g1u6o5IM4Un0vluv86cigLuBnjsKILffc=",
+        "lastModified": 1751741127,
+        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1965fd20a39c8e441746bee66d550af78f0c0a7b",
+        "rev": "29e290002bfff26af1db6f64d070698019460302",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,12 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-24.11";
+    home-manager.url = "github:nix-community/home-manager/release-25.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     agenix.url = "github:ryantm/agenix";
     agenix.inputs.nixpkgs.follows = "nixpkgs";

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -213,7 +213,7 @@
 
     firefox
 
-    xournal # editing pdfs
+    xournalpp # editing pdfs
     okular
     zathura
     breeze-icons # needed for okular

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -214,9 +214,9 @@
     firefox
 
     xournalpp # editing pdfs
-    okular
+    kdePackages.okular
     zathura
-    breeze-icons # needed for okular
+    kdePackages.breeze-icons # needed for okular
 
     silver-searcher
     unzip

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -216,7 +216,7 @@
     xournalpp # editing pdfs
     kdePackages.okular
     zathura
-    kdePackages.breeze-icons # needed for okular
+    #kdePackages.breeze-icons # needed for okular
 
     silver-searcher
     unzip

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -41,7 +41,7 @@
     alsa-utils
     hicolor-icon-theme
     shared-mime-info
-    plasma-workspace
+    kdePackages.plasma-workspace
     zenity
     usbutils
     pciutils

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -60,10 +60,11 @@
 		  corefonts  # Micrsoft free fonts
 		  unifont # some international languages
       powerline-fonts
-      anonymousPro
+      #anonymousPro
       emojione
       carlito
-      (nerdfonts.override { fonts = [ "AnonymousPro" "DroidSansMono" ]; })
+      nerd-fonts.anonymice
+      nerd-fonts.droid-sans-mono
       gyre-fonts
     ];
   };

--- a/pkgs/addr_search/default.nix
+++ b/pkgs/addr_search/default.nix
@@ -3,7 +3,7 @@
 
 pkgs.writeShellApplication {
   name = "addr_search"; 
-  runtimeInputs = with pkgs; [ python311Packages.goobook khard ];
+  runtimeInputs = with pkgs; [ goobook khard ];
   text = builtins.readFile ./addr_search;
 }
 

--- a/profiles/pim/taskwarrior/default.nix
+++ b/profiles/pim/taskwarrior/default.nix
@@ -119,7 +119,7 @@ in
     tmuxp # for the task view
     (callPackage ../../../pkgs/weekly-review {})
   ];
-  programs.zsh.initExtra = ''
+  programs.zsh.initContent = ''
     # open taskwarrior task in jira
     function twjira {
       readonly twid=''${1:?"A task id must be specified."}


### PR DESCRIPTION
- **nixos: 24.11 -> 25.05**
- **fix: xournal is now xournalapp**
- **fix: okular is no longer a top-level package**
- **fix: goobook is now a top-level package**
- **fix: individual nerd fonts are their own packages now**
- **fix: kde things are all under kdePackages now**
- **fix: breeze icons are handled by the flat-remix theme**
- **fix: zsh.initExtra is now zsh.initContent**
