### PR TITLE
nixos 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,16 +89,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1758463745,
-        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
+        "lastModified": 1764866045,
+        "narHash": "sha256-0GsEtXV9OquDQ1VclQfP16cU5VZh7NEVIOjSH4UaJuM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
+        "rev": "f63d0fe9d81d36e5fc95497217a72e02b8b7bcab",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762908663,
-        "narHash": "sha256-HqdYfzBaidYX+EYAcXDFCggXJPZBv2fusMwhc7/4+cI=",
+        "lastModified": 1764730608,
+        "narHash": "sha256-FxKIa3OCSRVC23qrk7VT68vExUcmSruJ8OobVlSWOxc=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "debc562c48c445f9f08778ecb9fc6b35197623ad",
+        "rev": "10124c58674360765adcb38c9a8b081fb72904e4",
         "type": "github"
       },
       "original": {
@@ -147,27 +147,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763049705,
-        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
+        "lastModified": 1764831616,
+        "narHash": "sha256-OtzF5wBvO0jgW1WW1rQU9cMGx7zuvkF7CAVJ1ypzkxA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
+        "rev": "c97c47f2bac4fa59e2cbdeba289686ae615f8ed4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,12 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-25.05";
+    home-manager.url = "github:nix-community/home-manager/release-25.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     agenix.url = "github:ryantm/agenix";
     agenix.inputs.nixpkgs.follows = "nixpkgs";

--- a/home-config/common.nix
+++ b/home-config/common.nix
@@ -26,8 +26,6 @@
       settings = {
         user.name = "Thomas Torsney-Weir";
         user.email = "torsneyt@gmail.com";
-      };
-      extraConfig = {
         credential = {
           helper = "store";
         };

--- a/home-config/common.nix
+++ b/home-config/common.nix
@@ -23,8 +23,10 @@
     git = {
       enable = true;
       lfs.enable = true;
-      userName = "Thomas Torsney-Weir";
-      userEmail = "torsneyt@gmail.com";
+      settings = {
+        user.name = "Thomas Torsney-Weir";
+        user.email = "torsneyt@gmail.com";
+      };
       extraConfig = {
         credential = {
           helper = "store";

--- a/home-config/common.nix
+++ b/home-config/common.nix
@@ -53,6 +53,7 @@
     };
     ssh = {
       enable = true;
+      enableDefaultConfig = false;
       matchBlocks = {
         "gitlab.com" = {
           hostname = "gitlab.com";

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -184,7 +184,7 @@
     yt-dlp
 
     exiftool
-    poppler_utils
+    poppler-utils
     #glib-networking # feedreader needs this for ssl
 
     libnotify

--- a/home-config/desktop.nix
+++ b/home-config/desktop.nix
@@ -197,7 +197,7 @@
 
     xclip
     xdotool
-    xdragon
+    dragon-drop
     feh
     sxiv
     viu

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -61,7 +61,6 @@
 		  unifont # some international languages
       powerline-fonts
       #anonymousPro
-      emojione
       carlito
       nerd-fonts.anonymice
       nerd-fonts.droid-sans-mono

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -116,7 +116,7 @@
       default_session = {
         # FIXME: ideally this would use the xsession stuff and not hack xinitrc
         command = builtins.concatStringsSep " " [
-          "${pkgs.greetd.tuigreet}/bin/tuigreet"
+          "${pkgs.tuigreet}/bin/tuigreet"
           "--theme 'border=gray;text=green;prompt=red;time=purple;action=blue;button=yellow;container=black;input=white'"
           "--window-padding 1"
           "--time"

--- a/pkgs/pancritic/default.nix
+++ b/pkgs/pancritic/default.nix
@@ -8,6 +8,9 @@ pypkgs.buildPythonApplication rec {
   pname = "pancritic";
   version = "0.3.1";
 
+  pyproject = true;
+  build-system = [ pkgs.python3Packages.setuptools ];
+
   src = pypkgs.fetchPypi {
     inherit pname version;
     sha256 = "1h74x42h8xqgxrrpmgalk5b3wis5njjmyrv3av8ah82wg10p3bhj";

--- a/pkgs/problog/default.nix
+++ b/pkgs/problog/default.nix
@@ -6,6 +6,9 @@ buildPythonPackage rec {
   pname = "problog";
   version = "2.2.4";
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     extension = "tar.gz";

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -80,8 +80,8 @@
     enable = true;
     extraPackages = with pkgs; [
       intel-media-driver # LIBVA_DRIVER_NAME=iHD
-      vaapiIntel         # LIBVA_DRIVER_NAME=i965 (older but works better for Firefox/Chromium)
-      vaapiVdpau
+      intel-vaapi-driver
+      libva-vdpau-driver
       libvdpau-va-gl
     ];
     enable32Bit = true;

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -121,9 +121,8 @@
     lidSwitch = "hibernate";
     #lidSwitchDocked = "hibernate";
     lidSwitchExternalPower = "hibernate";
-    extraConfig = ''
-      HandleSuspendKey = hibernate
-    '';
+    powerKey = "hibernate";
+    powerKeyLongPress = "poweroff";
   };
 
   # The remaining syncthing config

--- a/portege-configuration.nix
+++ b/portege-configuration.nix
@@ -117,12 +117,12 @@
 
   # set up sleep/hiberante
   services.logind = {
-    # FIXME: why doesn't this work!?!?!
-    lidSwitch = "hibernate";
-    #lidSwitchDocked = "hibernate";
-    lidSwitchExternalPower = "hibernate";
-    powerKey = "hibernate";
-    powerKeyLongPress = "poweroff";
+    settings.Login = {
+      HandleLidSwitch = "hibernate";
+      HandleLidSwitchExternalPower = "hibernate";
+      HandlePowerKey = "hibernate";
+      HandlePowerKeyLongPress = "poweroff";
+    };
   };
 
   # The remaining syncthing config

--- a/profiles/dev.nix
+++ b/profiles/dev.nix
@@ -14,8 +14,6 @@ in
 
     # git things
     git
-    gitAndTools.git-annex
-    gitAndTools.git-annex-remote-rclone
     gitAndTools.gh
     glab
 

--- a/profiles/dev.nix
+++ b/profiles/dev.nix
@@ -14,7 +14,7 @@ in
 
     # git things
     git
-    gitAndTools.gh
+    gh
     glab
 
     circleci-cli

--- a/profiles/pim/taskwarrior/default.nix
+++ b/profiles/pim/taskwarrior/default.nix
@@ -1,6 +1,7 @@
 { pkgs, lib, nixosConfig, ... }:
 
 let
+  taskwarrior-pkg = pkgs.taskwarrior2;
   bugwarrior-pkg = pkgs.python312Packages.bugwarrior;
 
   # Report definitions
@@ -160,7 +161,7 @@ in
     };
     Service = {
       Environment = "PATH=${
-        lib.makeBinPath (with pkgs; [ taskwarrior coreutils gnugrep ])
+        lib.makeBinPath (with pkgs; [ taskwarrior-pkg coreutils gnugrep ])
       }";
       ExecStart = "${bugwarrior-pkg}/bin/bugwarrior-pull";
     };

--- a/profiles/pim/taskwarrior/default.nix
+++ b/profiles/pim/taskwarrior/default.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, nixosConfig, ... }:
 
 let
-  bugwarrior-pkg = pkgs.python3.pkgs.bugwarrior;
+  bugwarrior-pkg = pkgs.python312Packages.bugwarrior;
 
   # Report definitions
   reports = {


### PR DESCRIPTION
- **feat: nixos 25.05 -> 25.11**
- **fix: popper_utils is now poppler-utils**
- **fix: tuigreet is now a top-level package**
- **feat: git-annex no longer used**
- **fix: gitAndTools stuff is now all top-level pacakges**
- **fix: 'xdragon' has been renamed to/replaced by 'dragon-drop'**
- **fix: need to distinguish pyproject builds now in custom python projects**
- **fix: python 3.13 bugwarrior is bugged**
- **fix: taskwarrior now has taskwarrior2 and taskwarrior3 versions**
- **fix: emojione font is gone**
- **feat: there are deadicated power button config items now**
- **fix: intel graphics drivers were renamed**
- **python packages need to specify how they are built**
- **fix: git.userName and git.userEmail were renamed**
- **fix: logind behaviors are now in settings.Login...**
- **fix: git puts all config stuff in one settings item now**
- **fix: future proof ssh**
